### PR TITLE
7325: adds client id to authentication error JSON message

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -17,7 +17,7 @@ class AuthController < ApplicationController
     application = Client.authenticate(params[:client_id], params[:client_secret])
 
     if application.nil?
-      render :json => {:error => "Could not find application"}
+      render :json => {:error => "Could not authenticate application with client id: #{params[:client_id]}"}
       return
     end
 


### PR DESCRIPTION
I have not yet tested this, as the SSO server seems to not be included in the test suite... 

Fixes (partially) 7325. 
